### PR TITLE
Updated registry events: register vendors and claim organisations

### DIFF
--- a/events/20200203000000000-RegisterNedapVendor.json
+++ b/events/20200203000000000-RegisterNedapVendor.json
@@ -1,0 +1,7 @@
+{
+  "type": "RegisterVendorEvent",
+  "payload": {
+    "identifier": "urn:oid:1.3.6.1.4.1.54851.4:00000001",
+    "name": "Nedap Healthcare"
+  }
+}

--- a/events/20200203000000000-RegisterNedapVendor.json
+++ b/events/20200203000000000-RegisterNedapVendor.json
@@ -1,7 +1,7 @@
 {
   "type": "RegisterVendorEvent",
   "payload": {
-    "identifier": "urn:oid:1.3.6.1.4.1.54851.4:00000001",
+    "identifier": "urn:oid:1.3.6.1.4.1.54851.4:08013836",
     "name": "Nedap Healthcare"
   }
 }

--- a/events/20200203000000003-MapNedapFhirEndpoint.json
+++ b/events/20200203000000003-MapNedapFhirEndpoint.json
@@ -1,8 +1,0 @@
-{
-  "type": "RegisterEndpointOrganizationEvent",
-  "payload": {
-    "status": "active",
-    "organization": "urn:oid:2.16.840.1.113883.2.4.6.1:48000000",
-    "endpoint": "6bc8273c-c23e-4cac-9f34-8f3359033175"
-  }
-}

--- a/events/20200203000000005-MapNedapCordaEndpoint.json
+++ b/events/20200203000000005-MapNedapCordaEndpoint.json
@@ -1,8 +1,0 @@
-{
-  "type": "RegisterEndpointOrganizationEvent",
-  "payload": {
-    "status": "active",
-    "organization": "urn:oid:2.16.840.1.113883.2.4.6.1:48000000",
-    "endpoint": "urn:ietf:rfc:1779:O=Nedap,C=NL,L=Groenlo,CN=nedap_nuts_cordapp_development"
-  }
-}

--- a/events/20200203000000008-MapCBoardsCordaEndpoint.json
+++ b/events/20200203000000008-MapCBoardsCordaEndpoint.json
@@ -1,8 +1,0 @@
-{
-  "type": "RegisterEndpointOrganizationEvent",
-  "payload": {
-    "status": "active",
-    "organization": "urn:oid:2.16.840.1.113883.2.4.6.1:12481248",
-    "endpoint": "urn:ietf:rfc:1779:O=CBoards,C=NL,L=Groenlo,CN=nuts_experimental-development-cboards"
-  }
-}

--- a/events/20200203000000010-RegisterNedapOrg.json
+++ b/events/20200203000000010-RegisterNedapOrg.json
@@ -1,7 +1,7 @@
 {
   "type": "VendorClaimEvent",
   "payload": {
-    "vendorIdentifier": "urn:oid:1.3.6.1.4.1.54851.4:00000001",
+    "vendorIdentifier": "urn:oid:1.3.6.1.4.1.54851.4:08013836",
     "orgName": "Nedap Healthcare Development",
     "orgIdentifier": "urn:oid:2.16.840.1.113883.2.4.6.1:48000000",
     "orgKeys": [

--- a/events/20200203000000010-RegisterNedapOrg.json
+++ b/events/20200203000000010-RegisterNedapOrg.json
@@ -1,9 +1,10 @@
 {
-  "type": "RegisterOrganizationEvent",
+  "type": "VendorClaimEvent",
   "payload": {
-    "name": "Nedap Healthcare Development",
-    "identifier": "urn:oid:2.16.840.1.113883.2.4.6.1:48000000",
-    "keys": [
+    "vendorIdentifier": "urn:oid:1.3.6.1.4.1.54851.4:00000001",
+    "orgName": "Nedap Healthcare Development",
+    "orgIdentifier": "urn:oid:2.16.840.1.113883.2.4.6.1:48000000",
+    "orgKeys": [
       {
         "kty": "RSA",
         "n": "uyyMO_v-1fZv_8Ee29feDJTwf8p1s_yPILLCt69hNM6CF1J7k4TfW_bl2qlQx2dxw-qOKyQFjPkBdAwJEoa3B9PKRPM7Mr2__ETUn8OgAec0aFZicAqAtGtyrN8VtY3bAX-hSwrNH6BTeElRUZMJuUsaCn4qLwo8mIGi_1GbIGr6GR8Fxv4Bg2SJpQktxOz9ut_y5NYUweEpluXn9-hGjz7uOydUBfAJHmEhNJzXSGz4giwijerzSn4KfOhYKM7PpFYtqtipPfBdpmiLpZH8bXUcTVF0hi3Wp6MTN3iFGkD_LdnzJSfZANwPjF3OdEook-NhhOPfL6QTYQlLPGxJXQ",

--- a/events/20200203000000020-RegisterNedapFhirEndpoint.json
+++ b/events/20200203000000020-RegisterNedapFhirEndpoint.json
@@ -1,6 +1,7 @@
 {
   "type": "RegisterEndpointEvent",
   "payload": {
+    "organization": "urn:oid:2.16.840.1.113883.2.4.6.1:48000000",
     "endpointType": "urn:nuts:endpoint:fhir",
     "identifier": "6bc8273c-c23e-4cac-9f34-8f3359033175",
     "status": "active",

--- a/events/20200203000000030-RegisterNedapCordaEndpoint.json
+++ b/events/20200203000000030-RegisterNedapCordaEndpoint.json
@@ -1,6 +1,7 @@
 {
   "type": "RegisterEndpointEvent",
   "payload": {
+    "organization": "urn:oid:2.16.840.1.113883.2.4.6.1:48000000",
     "endpointType": "urn:nuts:endpoint:consent",
     "identifier": "urn:ietf:rfc:1779:O=Nedap,C=NL,L=Groenlo,CN=nedap_nuts_cordapp_development",
     "status": "active",

--- a/events/20200203000000040-RegisterCareSharingVendor.json
+++ b/events/20200203000000040-RegisterCareSharingVendor.json
@@ -1,0 +1,7 @@
+{
+  "type": "RegisterVendorEvent",
+  "payload": {
+    "identifier": "urn:oid:1.3.6.1.4.1.54851.4:00000002",
+    "name": "CareSharing"
+  }
+}

--- a/events/20200203000000040-RegisterCareSharingVendor.json
+++ b/events/20200203000000040-RegisterCareSharingVendor.json
@@ -1,7 +1,7 @@
 {
   "type": "RegisterVendorEvent",
   "payload": {
-    "identifier": "urn:oid:1.3.6.1.4.1.54851.4:00000002",
+    "identifier": "urn:oid:1.3.6.1.4.1.54851.4:14105430",
     "name": "CareSharing"
   }
 }

--- a/events/20200203000000050-RegisterCBoardsOrg.json
+++ b/events/20200203000000050-RegisterCBoardsOrg.json
@@ -1,7 +1,7 @@
 {
   "type": "VendorClaimEvent",
   "payload": {
-    "vendorIdentifier": "urn:oid:1.3.6.1.4.1.54851.4:00000002",
+    "vendorIdentifier": "urn:oid:1.3.6.1.4.1.54851.4:14105430",
     "orgName": "CBoards Development",
     "orgIdentifier": "urn:oid:2.16.840.1.113883.2.4.6.1:12481248",
     "orgKeys": [

--- a/events/20200203000000050-RegisterCBoardsOrg.json
+++ b/events/20200203000000050-RegisterCBoardsOrg.json
@@ -1,9 +1,10 @@
 {
-  "type": "RegisterOrganizationEvent",
+  "type": "VendorClaimEvent",
   "payload": {
-    "name": "CBoards Development",
-    "identifier": "urn:oid:2.16.840.1.113883.2.4.6.1:12481248",
-    "keys": [
+    "vendorIdentifier": "urn:oid:1.3.6.1.4.1.54851.4:00000002",
+    "orgName": "CBoards Development",
+    "orgIdentifier": "urn:oid:2.16.840.1.113883.2.4.6.1:12481248",
+    "orgKeys": [
       {
         "kty": "RSA",
         "n": "25XlsYggeqianbWcr5z1eC97Y3sSdVAP-KodLFvSj_kVnHl8-ATcYc9bsdTd7dcJpcrWUgjuz3WvLVbZFhEvragXlI-kfJNJhjy2mUE2U_eKKCDgQ2xeXDqKDr6S77fhbB-3XL1VqNPi2ShQhbBU8roOM-BiACQMj6vNgza8tVoHj_UmATDdFqjmr3WLR-Atg1K8wPZC3us98UCEdIqBQF64AfRDNzmBLMycR3pmskIrmnuF8eSE7g3xGpmrdpInA6QU4AkmUvHN36ubCS2Mkj7h4PEq3JcPkBIDfVb_A_05PN7OZGdCjnu7FKW7glgIEkXDr3AGFuNqt8cb3YFE7w",

--- a/events/20200203000000060-RegisterCBoardsCordaEndpoint.json
+++ b/events/20200203000000060-RegisterCBoardsCordaEndpoint.json
@@ -1,6 +1,7 @@
 {
   "type": "RegisterEndpointEvent",
   "payload": {
+    "organization": "urn:oid:2.16.840.1.113883.2.4.6.1:12481248",
     "endpointType": "urn:nuts:endpoint:consent",
     "identifier": "urn:ietf:rfc:1779:O=CBoards,C=NL,L=Groenlo,CN=nuts_experimental-development-cboards",
     "status": "active",


### PR DESCRIPTION
Made the registry data compatible with 0.12.0.

Tested the changes for 0.12.0 against 0.11.2: output is the same, except that in 0.12.0 /api/organizations fills the endpoints field (previously it was an empty array).